### PR TITLE
✨ Specify type when querying for notifications

### DIFF
--- a/openbook_auth/models.py
+++ b/openbook_auth/models.py
@@ -2261,11 +2261,13 @@ class User(AbstractUser):
 
         return self.notifications.filter(notifications_query)
 
-    def read_notifications(self, max_id=None):
+    def read_notifications(self, max_id=None, types=None):
         notifications_query = Q(read=False)
 
         if max_id:
             notifications_query.add(Q(id__lte=max_id), Q.AND)
+        if types:
+            notifications_query.add(Q(notification_type__in=types), Q.AND)
 
         self.notifications.filter(notifications_query).update(read=True)
 

--- a/openbook_auth/models.py
+++ b/openbook_auth/models.py
@@ -2250,11 +2250,14 @@ class User(AbstractUser):
     def get_follow_for_user_with_id(self, user_id):
         return self.follows.get(followed_user_id=user_id)
 
-    def get_notifications(self, max_id=None):
+    def get_notifications(self, max_id=None, types=None):
         notifications_query = Q()
 
         if max_id:
             notifications_query.add(Q(id__lt=max_id), Q.AND)
+
+        if types:
+            notifications_query.add(Q(notification_type__in=types), Q.AND)
 
         return self.notifications.filter(notifications_query)
 

--- a/openbook_common/tests/helpers.py
+++ b/openbook_common/tests/helpers.py
@@ -202,8 +202,11 @@ def make_private_community(creator):
     return make_community(creator=creator, type=Community.COMMUNITY_TYPE_PRIVATE)
 
 
-def make_notification(owner):
-    return mixer.blend(Notification, owner=owner)
+def make_notification(owner, notification_type=None):
+    if notification_type:
+        return mixer.blend(Notification, owner=owner, notification_type=notification_type)
+    else:
+        return mixer.blend(Notification, owner=owner)
 
 
 def make_device(owner):

--- a/openbook_notifications/serializers.py
+++ b/openbook_notifications/serializers.py
@@ -30,6 +30,9 @@ class GetNotificationsSerializer(serializers.Serializer):
     max_id = serializers.IntegerField(
         required=False,
     )
+    types = serializers.CharField(
+        required=False,
+    )
 
 
 class PostCommentCommenterProfileSerializer(serializers.ModelSerializer):

--- a/openbook_notifications/serializers.py
+++ b/openbook_notifications/serializers.py
@@ -20,7 +20,10 @@ class ReadNotificationsSerializer(serializers.Serializer):
     max_id = serializers.IntegerField(
         required=False,
     )
-    types = serializers.CharField(
+    types = serializers.ListField(
+        child=serializers.CharField(
+            required=False,
+        ),
         required=False,
     )
 
@@ -33,7 +36,10 @@ class GetNotificationsSerializer(serializers.Serializer):
     max_id = serializers.IntegerField(
         required=False,
     )
-    types = serializers.CharField(
+    types = serializers.ListField(
+        child=serializers.CharField(
+            required=False,
+        ),
         required=False,
     )
 

--- a/openbook_notifications/serializers.py
+++ b/openbook_notifications/serializers.py
@@ -20,6 +20,9 @@ class ReadNotificationsSerializer(serializers.Serializer):
     max_id = serializers.IntegerField(
         required=False,
     )
+    types = serializers.CharField(
+        required=False,
+    )
 
 
 class GetNotificationsSerializer(serializers.Serializer):

--- a/openbook_notifications/serializers.py
+++ b/openbook_notifications/serializers.py
@@ -11,9 +11,9 @@ from openbook_notifications.models import Notification, PostCommentNotification,
     PostCommentReactionNotification, PostCommentUserMentionNotification, PostUserMentionNotification
 from openbook_notifications.models.post_reaction_notification import PostReactionNotification
 from openbook_notifications.serializer_fields import ParentCommentField
-from openbook_notifications.validators import notification_id_exists
 from openbook_posts.models import PostComment, PostReaction, Post, PostImage, PostVideo, PostCommentReaction, \
     PostUserMention, PostCommentUserMention
+from openbook_notifications.validators import notification_id_exists, notification_type_exists
 
 
 class ReadNotificationsSerializer(serializers.Serializer):
@@ -23,6 +23,7 @@ class ReadNotificationsSerializer(serializers.Serializer):
     types = serializers.ListField(
         child=serializers.CharField(
             required=False,
+            validators=[notification_type_exists],
         ),
         required=False,
     )
@@ -39,6 +40,7 @@ class GetNotificationsSerializer(serializers.Serializer):
     types = serializers.ListField(
         child=serializers.CharField(
             required=False,
+            validators=[notification_type_exists],
         ),
         required=False,
     )

--- a/openbook_notifications/tests/test_views.py
+++ b/openbook_notifications/tests/test_views.py
@@ -88,7 +88,7 @@ class ReadNotificationsAPITests(APITestCase):
 
         url = self._get_url()
         headers = make_authentication_headers_for_user(user)
-        response = self.client.post(url, **headers)
+        response = self.client.post(url, {}, **headers)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/openbook_notifications/validators.py
+++ b/openbook_notifications/validators.py
@@ -9,3 +9,12 @@ def notification_id_exists(notification_id):
         raise ValidationError(
             _('No notification with the provided id exists.'),
         )
+
+
+def notification_type_exists(notification_type):
+    matches = [a == notification_type for (a, b) in Notification.NOTIFICATION_TYPES]
+
+    if not any(matches):
+        raise ValidationError(
+            _('The provided notification type is invalid.'),
+        )

--- a/openbook_notifications/views.py
+++ b/openbook_notifications/views.py
@@ -22,7 +22,10 @@ class Notifications(APIView):
 
         count = data.get('count', 10)
         max_id = data.get('max_id')
-        types = data.get('types').split(sep=",")
+        types = data.get('types')
+
+        if types is not None:
+            types = types.split(sep=",")
 
         user = request.user
 
@@ -54,7 +57,10 @@ class ReadNotifications(APIView):
         data = serializer.validated_data
 
         max_id = data.get('max_id')
-        types = data.get('types').split(sep=",")
+        types = data.get('types')
+
+        if types is not None:
+            types = types.split(sep=",")
 
         with transaction.atomic():
             user.read_notifications(max_id=max_id, types=types)

--- a/openbook_notifications/views.py
+++ b/openbook_notifications/views.py
@@ -17,7 +17,7 @@ class Notifications(APIView):
         user = request.user
         query_params = request.query_params.dict()
 
-        if query_params['types'] is not None:
+        if 'types' in query_params:
             query_params['types'] = query_params['types'].split(sep=",")
 
         serializer = GetNotificationsSerializer(data=query_params)
@@ -52,7 +52,7 @@ class ReadNotifications(APIView):
         user = request.user
         query_data = request.data.dict()
 
-        if query_data['types'] is not None:
+        if 'types' in query_data:
             query_data['types'] = query_data['types'].split(sep=",")
 
         serializer = ReadNotificationsSerializer(data=query_data)

--- a/openbook_notifications/views.py
+++ b/openbook_notifications/views.py
@@ -54,9 +54,10 @@ class ReadNotifications(APIView):
         data = serializer.validated_data
 
         max_id = data.get('max_id')
+        types = data.get('types').split(sep=",")
 
         with transaction.atomic():
-            user.read_notifications(max_id=max_id)
+            user.read_notifications(max_id=max_id, types=types)
 
         return Response(status=status.HTTP_200_OK)
 

--- a/openbook_notifications/views.py
+++ b/openbook_notifications/views.py
@@ -22,10 +22,11 @@ class Notifications(APIView):
 
         count = data.get('count', 10)
         max_id = data.get('max_id')
+        types = data.get('types').split(sep=",")
 
         user = request.user
 
-        notifications = user.get_notifications(max_id=max_id).order_by('-created')[:count]
+        notifications = user.get_notifications(max_id=max_id, types=types).order_by('-created')[:count]
 
         response_serializer = GetNotificationsNotificationSerializer(notifications, many=True,
                                                                      context={"request": request})


### PR DESCRIPTION
This is the server-side changes required for Openbook APP PRs #[334](https://github.com/OpenbookOrg/openbook-app/pull/334) and #[251](https://github.com/OpenbookOrg/openbook-app/pull/251). It adds a 'types' parameter to the queries for getting notifications and marking notifications as read.

Does not introduce any breaking changes so it can be merged without the app-side PR.