### PR TITLE
:bug: User Adjective - fix titlecasing of letters immediately after a symbol

### DIFF
--- a/openbook_common/tests/helpers.py
+++ b/openbook_common/tests/helpers.py
@@ -1,4 +1,5 @@
 import tempfile
+import string
 
 from PIL import Image
 from faker import Faker
@@ -141,11 +142,11 @@ def make_community_rules():
 
 
 def make_community_user_adjective():
-    return fake.word().title()
+    return string.capwords(fake.word(), ' ')
 
 
 def make_community_users_adjective():
-    return fake.word().title()
+    return string.capwords(fake.word(), ' ')
 
 
 def make_community_name():

--- a/openbook_communities/models.py
+++ b/openbook_communities/models.py
@@ -1,3 +1,5 @@
+import string
+
 from django.conf import settings
 from django.db import models
 
@@ -439,10 +441,10 @@ class Community(models.Model):
         self.name = self.name.lower()
 
         if self.user_adjective:
-            self.user_adjective = self.user_adjective.title()
+            self.user_adjective = string.capwords(self.user_adjective, ' ')
 
         if self.users_adjective:
-            self.users_adjective = self.users_adjective.title()
+            self.users_adjective = string.capwords(self.users_adjective, ' ')
 
         return super(Community, self).save(*args, **kwargs)
 


### PR DESCRIPTION
Fixes https://github.com/OpenbookOrg/openbook-app/issues/243

(sorry, initially referenced 243 in the openbook-api repo instead of openbook-app)