### PR TITLE
:bug: fix duplicate notifications

### DIFF
--- a/openbook_auth/models.py
+++ b/openbook_auth/models.py
@@ -974,7 +974,7 @@ class User(AbstractUser):
         PostCommentNotification = get_post_comment_notification_model()
 
         for post_notification_target_user in post_notification_target_users:
-            if not post_notification_target_user.can_see_post(post=post):
+            if post_notification_target_user.pk == post_commenter.pk or not post_notification_target_user.can_see_post(post=post):
                 continue
             post_notification_target_user_is_post_creator = post_notification_target_user.id == post_creator.id
             post_notification_target_has_comment_notifications_enabled = post_notification_target_user.has_comment_notifications_enabled_for_post_with_id(
@@ -1032,7 +1032,7 @@ class User(AbstractUser):
         PostCommentReplyNotification = get_post_comment_reply_notification_model()
 
         for post_notification_target_user in post_notification_target_users:
-            if not post_notification_target_user.can_see_post(post=post):
+            if post_notification_target_user.pk == replier.pk or not post_notification_target_user.can_see_post(post=post):
                 continue
             post_notification_target_user_is_post_comment_creator = post_notification_target_user.id == comment_creator
             post_notification_target_has_comment_reply_notifications_enabled = \

--- a/openbook_posts/models.py
+++ b/openbook_posts/models.py
@@ -155,13 +155,9 @@ class Post(models.Model):
             Q(posts_comments__post_id=post.pk, posts_comments__parent_comment_id=None, ) & ~Q(
                 id=post_commenter.pk))
 
-        if post_commenter.pk == post.creator_id:
-            result = other_commenters
-        else:
-            post_creator = User.objects.filter(pk=post.creator_id)
-            result = other_commenters.union(post_creator)
+        post_creator = User.objects.filter(pk=post.creator_id)
 
-        return result
+        return other_commenters.union(post_creator)
 
     @classmethod
     def get_post_comment_reply_notification_target_users(cls, post_commenter, parent_post_comment):
@@ -175,14 +171,9 @@ class Post(models.Model):
             Q(posts_comments__parent_comment_id=parent_post_comment.pk, ) & ~Q(
                 id=post_commenter.pk))
 
-        if parent_post_comment.commenter_id == post_commenter.pk:
-            result = other_repliers
-        else:
-            # Add post comment creator
-            post_comment_creator = User.objects.filter(pk=parent_post_comment.commenter_id)
-            result = other_repliers.union(post_comment_creator)
-
-        return result
+        # Add post comment creator
+        post_comment_creator = User.objects.filter(pk=parent_post_comment.commenter_id)
+        return other_repliers.union(post_comment_creator)
 
     def count_comments(self):
         return PostComment.count_comments_for_post_with_id(self.pk)

--- a/openbook_posts/tests/views/test_post_comments.py
+++ b/openbook_posts/tests/views/test_post_comments.py
@@ -1312,8 +1312,8 @@ class PostCommentsAPITests(APITestCase):
         url = self._get_url(post)
         self.client.put(url, data, **headers)
 
-        self.assertTrue(PostCommentNotification.objects.filter(post_comment__text=post_comment_text,
-                                                               notification__owner=foreign_user).exists())
+        self.assertEqual(PostCommentNotification.objects.filter(post_comment__text=post_comment_text,
+                                                                notification__owner=foreign_user).count(), 1)
 
     def test_commenting_in_own_post_does_not_create_notification(self):
         """
@@ -1376,8 +1376,8 @@ class PostCommentsAPITests(APITestCase):
         url = self._get_url(post)
         self.client.put(url, data, **headers)
 
-        self.assertTrue(PostCommentNotification.objects.filter(post_comment__text=post_comment_text,
-                                                               notification__owner=foreign_user).exists())
+        self.assertEqual(PostCommentNotification.objects.filter(post_comment__text=post_comment_text,
+                                                                notification__owner=foreign_user).count(), 1)
 
     def test_commenting_in_commented_post_by_foreign_user_creates_foreign_notification_when_muted(self):
         """
@@ -1403,8 +1403,8 @@ class PostCommentsAPITests(APITestCase):
         url = self._get_url(post)
         self.client.put(url, data, **headers)
 
-        self.assertTrue(PostCommentNotification.objects.filter(post_comment__text=post_comment_text,
-                                                               notification__owner=foreign_user).exists())
+        self.assertEqual(PostCommentNotification.objects.filter(post_comment__text=post_comment_text,
+                                                                notification__owner=foreign_user).count(), 1)
 
     def test_comment_in_an_encircled_post_with_a_user_removed_from_the_circle_not_notifies_it(self):
         """


### PR DESCRIPTION
Sad solution really.. but how do we do reorganise the main query to accomplish what union does without doing distinct which does cross table comparing 🤕 