### PR TITLE
:ambulance: Stahp the proxy requests

### DIFF
--- a/.ebextensions/override_proxy_modules.config
+++ b/.ebextensions/override_proxy_modules.config
@@ -1,0 +1,17 @@
+files:
+  "/etc/httpd/conf.modules.d/00-proxy.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      # This file configures all the proxy modules:
+      LoadModule proxy_module modules/mod_proxy.so
+      LoadModule lbmethod_bybusyness_module modules/mod_lbmethod_bybusyness.so
+      LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so
+      LoadModule lbmethod_bytraffic_module modules/mod_lbmethod_bytraffic.so
+      LoadModule lbmethod_heartbeat_module modules/mod_lbmethod_heartbeat.so
+      LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+      LoadModule proxy_connect_module modules/mod_proxy_connect.so
+      LoadModule proxy_http_module modules/mod_proxy_http.so
+      LoadModule proxy_uwsgi_module modules/mod_proxy_uwsgi.so
+


### PR DESCRIPTION
AWS loads a lot of Apache modules by default. Including proxy modules that send alive requests to an internal service we are hosting. This generates unnecessary load and error conditions, therefore we disable it.