### PR TITLE
Bugfix/cant react to replied post comment

### DIFF
--- a/openbook_auth/checkers.py
+++ b/openbook_auth/checkers.py
@@ -1138,6 +1138,10 @@ def check_can_see_post_comment(user, post_comment):
         )
 
 
+def check_can_get_comment_for_post(user, post_comment, post, ):
+    check_can_see_post_comment(user=user, post_comment=post_comment)
+
+
 def check_can_get_global_moderated_objects(user):
     check_is_global_moderator(user=user)
 
@@ -1310,4 +1314,3 @@ def check_can_get_preview_link_data_for_post(user, post):
         raise ValidationError(
             _('No link associated with post.'),
         )
-

--- a/openbook_auth/models.py
+++ b/openbook_auth/models.py
@@ -1120,6 +1120,18 @@ class User(AbstractUser):
         post_comment.update_comment(text)
         return post_comment
 
+    def get_comment_with_id_for_post_with_uuid(self, post_comment_id, post_uuid):
+        Post = get_post_model()
+        post = Post.objects.get(uuid=post_uuid)
+
+        PostComment = get_post_comment_model()
+        post_comment = PostComment.objects.get(pk=post_comment_id)
+        return self.get_comment_for_post(post_comment=post_comment, post=post)
+
+    def get_comment_for_post(self, post, post_comment):
+        check_can_get_comment_for_post(user=self, post_comment=post_comment, post=post)
+        return post_comment
+
     def create_circle(self, name, color):
         check_circle_name_not_taken(user=self, circle_name=name)
         Circle = get_circle_model()
@@ -2057,10 +2069,13 @@ class User(AbstractUser):
         posts_prefetch_related = ('post__circles', 'post__creator__profile__badges')
 
         posts_only = ('id',
-                      'post__text', 'post__id', 'post__uuid', 'post__created', 'post__image__width', 'post__image__height', 'post__image__image',
-                      'post__creator__username', 'post__creator__id', 'post__creator__profile__name', 'post__creator__profile__avatar',
+                      'post__text', 'post__id', 'post__uuid', 'post__created', 'post__image__width',
+                      'post__image__height', 'post__image__image',
+                      'post__creator__username', 'post__creator__id', 'post__creator__profile__name',
+                      'post__creator__profile__avatar',
                       'post__creator__profile__badges__id', 'post__creator__profile__badges__keyword',
-                      'post__creator__profile__id', 'post__community__id', 'post__community__name', 'post__community__avatar',
+                      'post__creator__profile__id', 'post__community__id', 'post__community__name',
+                      'post__community__avatar',
                       'post__community__color', 'post__community__title')
 
         reported_posts_exclusion_query = ~Q(post__moderated_object__reports__reporter_id=self.pk)

--- a/openbook_posts/tests/views/test_post_comment.py
+++ b/openbook_posts/tests/views/test_post_comment.py
@@ -10,6 +10,7 @@ import logging
 from openbook_common.tests.helpers import make_authentication_headers_for_user, make_fake_post_text, \
     make_fake_post_comment_text, make_user, make_circle, make_community
 from openbook_common.utils.model_loaders import get_language_model
+from openbook_communities.models import Community
 from openbook_notifications.models import PostCommentNotification, Notification, PostCommentReplyNotification, \
     PostCommentUserMentionNotification
 from openbook_posts.models import PostComment, PostCommentUserMention
@@ -27,6 +28,197 @@ class PostCommentItemAPITests(OpenbookAPITestCase):
         'openbook_circles/fixtures/circles.json',
         'openbook_common/fixtures/languages.json'
     ]
+
+    def test_can_get_own_post_comment(self):
+        """
+          should be able to get an own comment in own post and return 200
+        """
+        user = make_user()
+
+        post = user.create_public_post(text=make_fake_post_text())
+
+        post_comment_text = make_fake_post_comment_text()
+
+        post_comment = user.comment_post_with_id(post.pk, text=post_comment_text)
+
+        url = self._get_url(post_comment=post_comment, post=post)
+
+        headers = make_authentication_headers_for_user(user)
+        response = self.client.get(url, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_can_get_foreign_public_post_comment(self):
+        """
+          should be able to get an own comment in a foreign public post and return 200
+        """
+        user = make_user()
+
+        post_creator = make_user()
+
+        commenter = make_user()
+
+        foreign_post = post_creator.create_public_post(text=make_fake_post_text())
+
+        post_comment_text = make_fake_post_comment_text()
+
+        post_comment = commenter.comment_post_with_id(foreign_post.pk, text=post_comment_text)
+
+        url = self._get_url(post_comment=post_comment, post=foreign_post)
+
+        headers = make_authentication_headers_for_user(user)
+        response = self.client.get(url, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_can_get_foreign_encircled_post_comment_part_of(self):
+        """
+          should be able to get a foreign encircled post comment part of and return 200
+        """
+        user = make_user()
+
+        post_creator = make_user()
+        circle = make_user()
+
+        post_creator.connect_with_user_with_id(user.pk)
+        user.confirm_connection_with_user_with_id(post_creator.pk)
+
+        commenter = make_user()
+
+        post_creator.connect_with_user_with_id(commenter.pk)
+        commenter.confirm_connection_with_user_with_id(post_creator.pk)
+
+        foreign_post = post_creator.create_encircled_post(text=make_fake_post_text(), circles_ids=[circle.pk])
+
+        post_comment_text = make_fake_post_comment_text()
+
+        post_comment = commenter.comment_post_with_id(foreign_post.pk, text=post_comment_text)
+
+        url = self._get_url(post_comment=post_comment, post=foreign_post)
+
+        headers = make_authentication_headers_for_user(user)
+        response = self.client.get(url, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_cant_get_foreign_encircled_post_comment_part_of(self):
+        """
+          should NOT be able to get a foreign encircled post comment NOT part of and return 400
+        """
+        user = make_user()
+
+        post_creator = make_user()
+        circle = make_user()
+
+        commenter = make_user()
+
+        post_creator.connect_with_user_with_id(commenter.pk)
+        commenter.confirm_connection_with_user_with_id(post_creator.pk)
+
+        foreign_post = post_creator.create_encircled_post(text=make_fake_post_text(), circles_ids=[circle.pk])
+
+        post_comment_text = make_fake_post_comment_text()
+
+        post_comment = commenter.comment_post_with_id(foreign_post.pk, text=post_comment_text)
+
+        url = self._get_url(post_comment=post_comment, post=foreign_post)
+
+        headers = make_authentication_headers_for_user(user)
+        response = self.client.get(url, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_can_get_public_community_post_comment(self):
+        """
+          should be able to get a comment in a public community post and return 200
+        """
+        user = make_user()
+
+        community_creator = make_user()
+        community = make_community(creator=community_creator)
+
+        community_post_creator = make_user()
+        community_post_creator.join_community_with_name(community_name=community.name)
+
+        community_post_commentator = make_user()
+        community_post_commentator.join_community_with_name(community_name=community.name)
+
+        post = community_post_creator.create_community_post(text=make_fake_post_text(), community_name=community.name)
+        post_comment = community_post_commentator.comment_post_with_id(text=make_fake_post_comment_text(),
+                                                                       post_id=post.pk)
+
+        url = self._get_url(post_comment=post_comment, post=post)
+
+        headers = make_authentication_headers_for_user(user)
+        response = self.client.get(url, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_can_get_private_community_post_comment_part_of(self):
+        """
+          should be able to get a comment in a private community part of post and return 200
+        """
+        user = make_user()
+
+        community_creator = make_user()
+        community = make_community(creator=community_creator, type=Community.COMMUNITY_TYPE_PRIVATE)
+
+        community_creator.invite_user_with_username_to_community_with_name(username=user.username,
+                                                                           community_name=community.name)
+        user.join_community_with_name(community_name=community.name)
+
+        community_post_creator = make_user()
+        community_creator.invite_user_with_username_to_community_with_name(username=community_post_creator.username,
+                                                                           community_name=community.name)
+        community_post_creator.join_community_with_name(community_name=community.name)
+
+        community_post_commentator = make_user()
+        community_creator.invite_user_with_username_to_community_with_name(
+            username=community_post_commentator.username,
+            community_name=community.name)
+        community_post_commentator.join_community_with_name(community_name=community.name)
+
+        post = community_post_creator.create_community_post(text=make_fake_post_text(), community_name=community.name)
+        post_comment = community_post_commentator.comment_post_with_id(text=make_fake_post_comment_text(),
+                                                                       post_id=post.pk)
+
+        url = self._get_url(post_comment=post_comment, post=post)
+
+        headers = make_authentication_headers_for_user(user)
+        response = self.client.get(url, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_cant_get_private_community_post_comment_not_part_of(self):
+        """
+          should NOT be able to get a comment in a private community NOT part of post and return 200
+        """
+        user = make_user()
+
+        community_creator = make_user()
+        community = make_community(creator=community_creator, type=Community.COMMUNITY_TYPE_PRIVATE)
+
+        community_post_creator = make_user()
+        community_creator.invite_user_with_username_to_community_with_name(username=community_post_creator.username,
+                                                                           community_name=community.name)
+        community_post_creator.join_community_with_name(community_name=community.name)
+
+        community_post_commentator = make_user()
+        community_creator.invite_user_with_username_to_community_with_name(
+            username=community_post_commentator.username,
+            community_name=community.name)
+        community_post_commentator.join_community_with_name(community_name=community.name)
+
+        post = community_post_creator.create_community_post(text=make_fake_post_text(), community_name=community.name)
+        post_comment = community_post_commentator.comment_post_with_id(text=make_fake_post_comment_text(),
+                                                                       post_id=post.pk)
+
+        url = self._get_url(post_comment=post_comment, post=post)
+
+        headers = make_authentication_headers_for_user(user)
+        response = self.client.get(url, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_can_delete_foreign_comment_in_own_post(self):
         """

--- a/openbook_posts/views/post_comment/serializers.py
+++ b/openbook_posts/views/post_comment/serializers.py
@@ -37,7 +37,7 @@ class DeletePostCommentSerializer(serializers.Serializer):
     )
 
 
-class GetPostCommentSerializer(serializers.Serializer):
+class GetPostCommentRequestSerializer(serializers.Serializer):
     post_uuid = serializers.UUIDField(
         validators=[post_uuid_exists],
         required=True,

--- a/openbook_posts/views/post_comment/views.py
+++ b/openbook_posts/views/post_comment/views.py
@@ -10,7 +10,7 @@ from openbook_common.utils.helpers import get_post_id_for_post_uuid
 from openbook_moderation.permissions import IsNotSuspended
 from openbook_posts.views.post_comment.serializers import DeletePostCommentSerializer, UpdatePostCommentSerializer, \
     EditPostCommentSerializer, MutePostCommentSerializer, UnmutePostCommentSerializer, TranslatePostCommentSerializer, \
-    GetPostCommentSerializer
+    GetPostCommentSerializer, GetPostCommentRequestSerializer
 from openbook_translation.strategies.base import UnsupportedLanguagePairException, TranslationClientError, \
     MaxTextLengthExceededError
 
@@ -19,9 +19,10 @@ class PostCommentItem(APIView):
     permission_classes = (IsAuthenticated, IsNotSuspended)
 
     def get(self, request, post_uuid, post_comment_id):
-        request_data = self._get_request_data(request, post_uuid, post_comment_id)
-
-        serializer = GetPostCommentSerializer(data=request_data)
+        serializer = GetPostCommentRequestSerializer(data={
+            'post_uuid': post_uuid,
+            'post_comment_id': post_comment_id
+        })
         serializer.is_valid(raise_exception=True)
 
         data = serializer.validated_data

--- a/video_encoding/files.py
+++ b/video_encoding/files.py
@@ -5,7 +5,6 @@ from django.core.files import File
 from video_encoding.utils import get_fieldfile_local_path
 from .backends import get_backend
 
-
 class VideoFile(File):
     """
     A mixin for use alongside django.core.files.base.File, which provides
@@ -44,6 +43,9 @@ class VideoFile(File):
             encoding_backend = get_backend()
 
             local_path, local_tmp_file = get_fieldfile_local_path(fieldfile=self)
+
+            if (not local_path or not os.path.exists(local_path)) or (local_tmp_file and not os.path.exists(local_tmp_file)):
+                return {}
 
             info_cache = encoding_backend.get_media_info(local_path)
 


### PR DESCRIPTION
When building the post comment replies, we forgot to add a way to load the reactions of the post comment being replied to when navigating to it. Resulting in not seeing existing reactions nor being able to react as the reactions count is `null`.

This PR adds an endpoint for retrieving individual comments and gets called together with the `refreshPost` on the comments widget.