### PR TITLE
:sparkles: Iterate over all configured queues  

### DIFF
--- a/openbook_common/jobs.py
+++ b/openbook_common/jobs.py
@@ -3,38 +3,47 @@ from django_rq.decorators import job
 from openbook_common.utils.rq_helpers import RQStats
 from openbook_common.helpers import send_alert_to_channel
 
-from openbook.settings import FAILED_JOB_THRESHOLD
+from openbook.settings import RQ_QUEUES, FAILED_JOB_THRESHOLD
 from openbook.settings import ACTIVE_JOB_THRESHOLD, ACTIVE_WORKER_THRESHOLD
 
 
 @job
 def verify_failed_job_threshold():
 
-    rq_stats = RQStats()
-    failed_job_count = rq_stats.get_failed_job_count()
+    # iterate through all configured queues
+    for queue in RQ_QUEUES.keys():
 
-    if failed_job_count >= FAILED_JOB_THRESHOLD:
-        send_alert_to_channel(f"*OH NOES: we haz too many failed jobs "
-                              f"({failed_job_count})!!*")
+        rq_stats = RQStats(queue)
+        failed_job_count = rq_stats.get_failed_job_count()
+
+        if failed_job_count >= FAILED_JOB_THRESHOLD:
+            send_alert_to_channel(f"*OH NOES: we haz too many failed jobs "
+                                  f"in {queue}: ({failed_job_count})!!*")
 
 
 @job
 def verify_active_job_threshold():
 
-    rq_stats = RQStats()
-    active_job_count = rq_stats.get_active_job_count()
+    for queue in RQ_QUEUES.keys():
 
-    if active_job_count >= ACTIVE_JOB_THRESHOLD:
-        send_alert_to_channel(f"*UH-OH: we have way too many active jobs right "
-                              f"now: {active_job_count}!!*")
+        rq_stats = RQStats(queue)
+        active_job_count = rq_stats.get_active_job_count(queue)
+
+        if active_job_count >= ACTIVE_JOB_THRESHOLD:
+            send_alert_to_channel(
+                    f"*UH-OH: we have way too many active jobs "
+                    f"in {queue} right now: {active_job_count}!!*"
+                                  )
 
 
 @job
 def verify_active_worker_threshold():
 
-    rq_stats = RQStats()
-    active_worker_count = rq_stats.get_active_worker_count()
+    for queue in RQ_QUEUES.keys():
 
-    if active_worker_count >= ACTIVE_WORKER_THRESHOLD:
-        send_alert_to_channel(f"*Hmm, we are not supposed to have "
-                              f"{active_worker_count} workers*")
+        rq_stats = RQStats(queue)
+        active_worker_count = rq_stats.get_active_worker_count()
+
+        if active_worker_count >= ACTIVE_WORKER_THRESHOLD:
+            send_alert_to_channel(f"*Hmm, we are not supposed to have "
+                                  f"{active_worker_count} workers in {queue}*")

--- a/openbook_common/utils/rq_helpers.py
+++ b/openbook_common/utils/rq_helpers.py
@@ -4,10 +4,10 @@ from django_rq.utils import get_statistics, FailedJobRegistry
 
 class RQStats():
 
-    def __init__(self):
+    def __init__(self, queue):
 
         self.stats = get_statistics()
-        self.queue_name = 'default'
+        self.queue_name = queue
 
     def get_active_worker_count(self):
 
@@ -43,9 +43,9 @@ class RQStats():
 
 class FailedRQJobs():
 
-    def __init__(self):
+    def __init__(self, queue):
 
-        self.queue = django_rq.get_queue('default')
+        self.queue = django_rq.get_queue(queue)
         self.connection = django_rq.get_connection()
         self.failed_job_registry = FailedJobRegistry(self.queue,
                                                      self.connection)


### PR DESCRIPTION
As #566 added more queues, the RQ monitoring jobs will now iterate over all the queues that are configured through the `RQ_QUEUES` setting in `settings.py`.