### PR TITLE
:zap: Adding more PATH variables

### DIFF
--- a/.ebextensions/health_worker.config
+++ b/.ebextensions/health_worker.config
@@ -4,5 +4,5 @@ files:
     owner: ec2-user
     group: ec2-user
     content: |
-      PATH="/opt/python/run/venv/bin:$PATH"
+      PATH="/opt/python/run/venv/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin"
       */5 * * * * . /opt/python/current/env; cd /opt/python/current/app; ./manage.py worker_health_check > /dev/null 2>&1


### PR DESCRIPTION
Currently the mail spool is receiving messages about not being able to
find `grep`, `sed` and `awk`, due to the PATH overwrite.