### PR TITLE
:fire: Method is unreliable removing failed job reporting

### DIFF
--- a/openbook_common/management/commands/worker_health_check.py
+++ b/openbook_common/management/commands/worker_health_check.py
@@ -25,17 +25,6 @@ class Command(BaseCommand):
         for queue in RQ_QUEUES.keys():
 
             rq_stats = RQStats(queue)
-            failed_job_count = rq_stats.get_failed_job_count()
-
-            if failed_job_count >= FAILED_JOB_THRESHOLD:
-                send_alert_to_channel(
-                        f"*OH NOES: we haz too many failed jobs "
-                        f"in {env}:{queue}: ({failed_job_count})!!*")
-                print(
-                   f"{env}:{queue} has too many failed jobs {failed_job_count}"
-                     )
-
-                self.retval += 1
 
             active_job_count = rq_stats.get_active_job_count()
 


### PR DESCRIPTION
It is not a reliable metric. Failed queue will be cleared by Redis every 7 days. Removing this code for now, a better measuring method will be added soon.