### PR TITLE
Hotfix/split post counts

### DIFF
--- a/openbook/settings.py
+++ b/openbook/settings.py
@@ -360,7 +360,8 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
-    )
+    ),
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning'
 }
 
 # AWS Translate

--- a/openbook/urls.py
+++ b/openbook/urls.py
@@ -30,7 +30,8 @@ from openbook_auth.views.followers.views import Followers, SearchFollowers
 from openbook_auth.views.following.views import Followings, SearchFollowings
 from openbook_auth.views.linked_users.views import LinkedUsers, SearchLinkedUsers
 from openbook_auth.views.proxy.views import ProxyAuth
-from openbook_auth.views.users.views import SearchUsers, GetUser, BlockUser, UnblockUser, SubscribeToUserNewPostNotifications
+from openbook_auth.views.users.views import SearchUsers, GetUser, BlockUser, UnblockUser, \
+    SubscribeToUserNewPostNotifications, GetUserPostsCount
 from openbook_categories.views import Categories
 from openbook_circles.views import Circles, CircleItem, CircleNameCheck
 from openbook_common.views import Time, Health, EmojiGroups, ProxyDomainCheck
@@ -46,7 +47,8 @@ from openbook_communities.views.community.members.views import CommunityMembers,
     LeaveCommunity, InviteCommunityMember, SearchCommunityMembers, UninviteCommunityMember
 from openbook_communities.views.community.moderators.views import CommunityModeratorItem, CommunityModerators, \
     SearchCommunityModerators
-from openbook_communities.views.community.posts.views import CommunityPosts, ClosedCommunityPosts
+from openbook_communities.views.community.posts.views import CommunityPosts, ClosedCommunityPosts, \
+    GetCommunityPostsCount
 from openbook_communities.views.community.views import CommunityItem, CommunityAvatar, CommunityCover, \
     FavoriteCommunity, \
     TopPostCommunityExclusion, SubscribeToCommunityNewPostNotifications
@@ -111,7 +113,9 @@ auth_users_user_patterns = [
     path('block/', BlockUser.as_view(), name='block-user'),
     path('unblock/', UnblockUser.as_view(), name='unblock-user'),
     path('report/', ReportUser.as_view(), name='report-user'),
-    path('notifications/subscribe/new-post/', SubscribeToUserNewPostNotifications.as_view(), name='subscribe-user-new-post-notifications'),
+    path('notifications/subscribe/new-post/', SubscribeToUserNewPostNotifications.as_view(),
+         name='subscribe-user-new-post-notifications'),
+    path('posts/count/', GetUserPostsCount.as_view(), name='user-posts-count'),
 ]
 
 auth_users_patterns = [
@@ -245,6 +249,7 @@ community_members_patterns = [
 community_posts_patterns = [
     path('', CommunityPosts.as_view(), name='community-posts'),
     path('closed/', ClosedCommunityPosts.as_view(), name='closed-community-posts'),
+    path('count/', GetCommunityPostsCount.as_view(), name='community-posts-count'),
 ]
 
 community_banned_users_patterns = [

--- a/openbook_auth/views/authenticated_user/serializers.py
+++ b/openbook_auth/views/authenticated_user/serializers.py
@@ -13,7 +13,7 @@ from openbook_common.serializers_fields.request import FriendlyUrlField, Restric
 from openbook_common.serializers_fields.user import FollowersCountField, \
     FollowingCountField, \
     IsMemberOfCommunities, \
-    UnreadNotificationsCountField, IsGlobalModeratorField
+    UnreadNotificationsCountField, IsGlobalModeratorField, UserPostsCountField
 from openbook_common.validators import name_characters_validator, language_id_exists
 from openbook_moderation.serializers_fields.user import UserPendingCommunitiesModeratedObjectsCountField, \
     UserActiveModerationPenaltiesCountField
@@ -50,7 +50,6 @@ class GetAuthenticatedUserProfileSerializer(serializers.ModelSerializer):
 
 
 class UserLanguageSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = Language
         fields = (
@@ -82,6 +81,42 @@ class GetAuthenticatedUserSerializer(serializers.ModelSerializer):
             'language',
             'invite_count',
             'date_joined',
+            'are_guidelines_accepted',
+            'followers_count',
+            'following_count',
+            'connections_circle_id',
+            'is_member_of_communities',
+            'is_global_moderator',
+            'unread_notifications_count',
+            'pending_communities_moderated_objects_count',
+            'active_moderation_penalties_count',
+        )
+
+
+class LegacyGetAuthenticatedUserSerializer(serializers.ModelSerializer):
+    profile = GetAuthenticatedUserProfileSerializer(many=False)
+    unread_notifications_count = UnreadNotificationsCountField()
+    followers_count = FollowersCountField()
+    is_global_moderator = IsGlobalModeratorField()
+    posts_count = UserPostsCountField()
+    following_count = FollowingCountField()
+    is_member_of_communities = IsMemberOfCommunities()
+    pending_communities_moderated_objects_count = UserPendingCommunitiesModeratedObjectsCountField()
+    active_moderation_penalties_count = UserActiveModerationPenaltiesCountField()
+    language = UserLanguageSerializer()
+
+    class Meta:
+        model = User
+        fields = (
+            'id',
+            'uuid',
+            'email',
+            'username',
+            'profile',
+            'language',
+            'invite_count',
+            'date_joined',
+            'posts_count',
             'are_guidelines_accepted',
             'followers_count',
             'following_count',
@@ -145,7 +180,6 @@ class AuthenticatedUserLanguageSerializer(serializers.Serializer):
 
 
 class AuthenticatedUserAllLanguagesSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = Language
         fields = (

--- a/openbook_auth/views/authenticated_user/serializers.py
+++ b/openbook_auth/views/authenticated_user/serializers.py
@@ -11,7 +11,7 @@ from django.contrib.auth.password_validation import validate_password
 from openbook_common.models import Badge, Language
 from openbook_common.serializers_fields.request import FriendlyUrlField, RestrictedImageFileSizeField
 from openbook_common.serializers_fields.user import FollowersCountField, \
-    FollowingCountField, PostsCountField, \
+    FollowingCountField, \
     IsMemberOfCommunities, \
     UnreadNotificationsCountField, IsGlobalModeratorField
 from openbook_common.validators import name_characters_validator, language_id_exists
@@ -62,7 +62,6 @@ class UserLanguageSerializer(serializers.ModelSerializer):
 
 class GetAuthenticatedUserSerializer(serializers.ModelSerializer):
     profile = GetAuthenticatedUserProfileSerializer(many=False)
-    posts_count = PostsCountField()
     unread_notifications_count = UnreadNotificationsCountField()
     followers_count = FollowersCountField()
     is_global_moderator = IsGlobalModeratorField()
@@ -81,7 +80,6 @@ class GetAuthenticatedUserSerializer(serializers.ModelSerializer):
             'username',
             'profile',
             'language',
-            'posts_count',
             'invite_count',
             'date_joined',
             'are_guidelines_accepted',

--- a/openbook_auth/views/users/serializers.py
+++ b/openbook_auth/views/users/serializers.py
@@ -134,6 +134,43 @@ class GetUserUserSerializer(serializers.ModelSerializer):
         )
 
 
+class LegacyGetUserUserSerializer(serializers.ModelSerializer):
+    profile = GetUserUserProfileSerializer(many=False)
+    followers_count = FollowersCountField()
+    following_count = FollowingCountField()
+    posts_count = UserPostsCountField()
+    is_following = IsFollowingField()
+    is_followed = IsFollowedField()
+    are_new_post_notifications_enabled = AreNewPostNotificationsEnabledForUserField()
+    is_connected = IsConnectedField()
+    is_fully_connected = IsFullyConnectedField()
+    connected_circles = ConnectedCirclesField(circle_serializer=GetUserUserCircleSerializer)
+    follow_lists = FollowListsField(list_serializer=GetUserUserListSerializer)
+    is_pending_connection_confirmation = IsPendingConnectionConfirmation()
+    is_reported = IsUserReportedField()
+
+    class Meta:
+        model = User
+        fields = (
+            'id',
+            'username',
+            'profile',
+            'followers_count',
+            'following_count',
+            'posts_count',
+            'is_following',
+            'is_followed',
+            'are_new_post_notifications_enabled',
+            'is_connected',
+            'is_reported',
+            'is_fully_connected',
+            'connected_circles',
+            'follow_lists',
+            'date_joined',
+            'is_pending_connection_confirmation'
+        )
+
+
 class GetBlockedUserSerializer(serializers.ModelSerializer):
     is_blocked = IsBlockedField()
     is_following = IsFollowingField()

--- a/openbook_auth/views/users/serializers.py
+++ b/openbook_auth/views/users/serializers.py
@@ -5,7 +5,7 @@ from openbook_auth.models import UserProfile, User
 from openbook_auth.validators import username_characters_validator, user_username_exists
 from openbook_circles.models import Circle
 from openbook_common.models import Badge, Emoji
-from openbook_common.serializers_fields.user import FollowersCountField, FollowingCountField, PostsCountField, \
+from openbook_common.serializers_fields.user import FollowersCountField, FollowingCountField, UserPostsCountField, \
     IsFollowingField, IsConnectedField, IsFullyConnectedField, ConnectedCirclesField, FollowListsField, \
     IsPendingConnectionConfirmation, IsBlockedField, IsUserReportedField, IsFollowedField, \
     AreNewPostNotificationsEnabledForUserField
@@ -103,7 +103,6 @@ class GetUserUserSerializer(serializers.ModelSerializer):
     profile = GetUserUserProfileSerializer(many=False)
     followers_count = FollowersCountField()
     following_count = FollowingCountField()
-    posts_count = PostsCountField()
     is_following = IsFollowingField()
     is_followed = IsFollowedField()
     are_new_post_notifications_enabled = AreNewPostNotificationsEnabledForUserField()
@@ -122,7 +121,6 @@ class GetUserUserSerializer(serializers.ModelSerializer):
             'profile',
             'followers_count',
             'following_count',
-            'posts_count',
             'is_following',
             'is_followed',
             'are_new_post_notifications_enabled',
@@ -211,4 +209,15 @@ class SubscribeToUserNewPostNotificationsUserSerializer(serializers.ModelSeriali
         fields = (
             'id',
             'are_new_post_notifications_enabled',
+        )
+
+
+class GetUserPostsCountUserSerializer(serializers.ModelSerializer):
+    posts_count = UserPostsCountField()
+
+    class Meta:
+        model = User
+        fields = (
+            'id',
+            'posts_count',
         )

--- a/openbook_auth/views/users/views.py
+++ b/openbook_auth/views/users/views.py
@@ -147,9 +147,12 @@ class SubscribeToUserNewPostNotifications(APIView):
 class GetUserPostsCount(APIView):
     permission_classes = (IsAuthenticated, IsNotSuspended)
 
-    def get(self, request, username):
-        serializer = GetUserSerializer(data={'username': username})
+    def get(self, request, user_username):
+        serializer = GetUserSerializer(data={'username': user_username})
         serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        username = data.get('username')
 
         user = request.user
 

--- a/openbook_common/serializers_fields/user.py
+++ b/openbook_common/serializers_fields/user.py
@@ -191,11 +191,11 @@ class FollowingCountField(Field):
         return value.count_following()
 
 
-class PostsCountField(Field):
+class UserPostsCountField(Field):
     def __init__(self, **kwargs):
         kwargs['source'] = '*'
         kwargs['read_only'] = True
-        super(PostsCountField, self).__init__(**kwargs)
+        super(UserPostsCountField, self).__init__(**kwargs)
 
     def to_representation(self, value):
         request = self.context.get('request')

--- a/openbook_communities/views/community/posts/serializers.py
+++ b/openbook_communities/views/community/posts/serializers.py
@@ -4,9 +4,11 @@ from rest_framework import serializers
 from openbook_common.serializers import CommonPostImageSerializer, CommonPostCreatorSerializer, \
     CommonCommunityMembershipSerializer, CommonPostEmojiCountSerializer, CommonPostCommunitySerializer, \
     CommonPostReactionSerializer, CommonPostLanguageSerializer, CommonHashtagSerializer
+from openbook_common.serializers_fields.community import CommunityPostsCountField
 from openbook_common.serializers_fields.post import PostReactionsEmojiCountField, CommentsCountField, PostCreatorField, \
     PostIsMutedField, ReactionField
 from openbook_common.serializers_fields.request import RestrictedImageFileSizeField
+from openbook_communities.models import Community
 from openbook_communities.validators import community_name_characters_validator, community_name_exists
 from openbook_posts.models import Post
 from openbook_posts.validators import post_text_validators
@@ -74,4 +76,22 @@ class CommunityPostSerializer(serializers.ModelSerializer):
             'media_width',
             'media_thumbnail',
             'hashtags'
+        )
+
+
+class GetCommunityPostsCountsSerializer(serializers.Serializer):
+    community_name = serializers.CharField(max_length=settings.COMMUNITY_NAME_MAX_LENGTH,
+                                           allow_blank=False,
+                                           required=True,
+                                           validators=[community_name_characters_validator, community_name_exists])
+
+
+class GetCommunityPostsCountCommunitySerializer(serializers.ModelSerializer):
+    posts_count = CommunityPostsCountField()
+
+    class Meta:
+        model = Community
+        fields = (
+            'id',
+            'posts_count',
         )

--- a/openbook_communities/views/community/posts/views.py
+++ b/openbook_communities/views/community/posts/views.py
@@ -7,7 +7,7 @@ from rest_framework.views import APIView
 from openbook_moderation.permissions import IsNotSuspended
 from openbook_common.utils.helpers import normalise_request_data
 from openbook_communities.views.community.posts.serializers import GetCommunityPostsSerializer, CommunityPostSerializer, \
-    CreateCommunityPostSerializer
+    CreateCommunityPostSerializer, GetCommunityPostsCountsSerializer, GetCommunityPostsCountCommunitySerializer
 
 
 class CommunityPosts(APIView):
@@ -82,5 +82,20 @@ class ClosedCommunityPosts(APIView):
 
         response_serializer = CommunityPostSerializer(posts, many=True,
                                                       context={"request": request})
+
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+
+class GetCommunityPostsCount(APIView):
+    permission_classes = (IsAuthenticated, IsNotSuspended)
+
+    def get(self, request, community_name):
+        serializer = GetCommunityPostsCountsSerializer(data={'community_name': community_name})
+        serializer.is_valid(raise_exception=True)
+
+        user = request.user
+        community = user.get_community_with_name(community_name)
+
+        response_serializer = GetCommunityPostsCountCommunitySerializer(community, context={"request": request})
 
         return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/openbook_communities/views/community/serializers.py
+++ b/openbook_communities/views/community/serializers.py
@@ -5,7 +5,7 @@ from openbook_auth.models import User, UserProfile
 from openbook_categories.models import Category
 from openbook_categories.validators import category_name_exists
 from openbook_common.models import Badge
-from openbook_common.serializers_fields.community import IsCommunityReportedField
+from openbook_common.serializers_fields.community import IsCommunityReportedField, CommunityPostsCountField
 from openbook_common.serializers_fields.request import RestrictedImageFileSizeField
 from openbook_common.serializers_fields.user import IsFollowingField, AreNewPostNotificationsEnabledForUserField
 from openbook_common.validators import hex_color_validator
@@ -170,6 +170,48 @@ class GetCommunityCommunitySerializer(serializers.ModelSerializer):
             'avatar',
             'cover',
             'members_count',
+            'color',
+            'description',
+            'rules',
+            'user_adjective',
+            'users_adjective',
+            'categories',
+            'moderators',
+            'administrators',
+            'type',
+            'invites_enabled',
+            'is_invited',
+            'are_new_post_notifications_enabled',
+            'is_creator',
+            'is_favorite',
+            'is_reported',
+            'memberships',
+        )
+
+
+class LegacyGetCommunityCommunitySerializer(serializers.ModelSerializer):
+    categories = GetCommunityCommunityCategorySerializer(many=True)
+    is_invited = IsInvitedField()
+    are_new_post_notifications_enabled = AreNewPostNotificationsEnabledForCommunityField()
+    is_creator = IsCreatorField()
+    is_favorite = IsFavoriteField()
+    is_reported = IsCommunityReportedField()
+    posts_count = CommunityPostsCountField()
+    moderators = ModeratorsField(moderator_serializer=GetCommunityStaffUserSerializer)
+    administrators = AdministratorsField(administrator_serializer=GetCommunityStaffUserSerializer)
+    memberships = CommunityMembershipsField(community_membership_serializer=GetCommunityCommunityMembershipSerializer)
+    rules = RulesField()
+
+    class Meta:
+        model = Community
+        fields = (
+            'id',
+            'title',
+            'name',
+            'avatar',
+            'cover',
+            'members_count',
+            'posts_count',
             'color',
             'description',
             'rules',

--- a/openbook_communities/views/community/serializers.py
+++ b/openbook_communities/views/community/serializers.py
@@ -5,7 +5,7 @@ from openbook_auth.models import User, UserProfile
 from openbook_categories.models import Category
 from openbook_categories.validators import category_name_exists
 from openbook_common.models import Badge
-from openbook_common.serializers_fields.community import IsCommunityReportedField, CommunityPostsCountField
+from openbook_common.serializers_fields.community import IsCommunityReportedField
 from openbook_common.serializers_fields.request import RestrictedImageFileSizeField
 from openbook_common.serializers_fields.user import IsFollowingField, AreNewPostNotificationsEnabledForUserField
 from openbook_common.validators import hex_color_validator
@@ -160,7 +160,6 @@ class GetCommunityCommunitySerializer(serializers.ModelSerializer):
     administrators = AdministratorsField(administrator_serializer=GetCommunityStaffUserSerializer)
     memberships = CommunityMembershipsField(community_membership_serializer=GetCommunityCommunityMembershipSerializer)
     rules = RulesField()
-    posts_count = CommunityPostsCountField()
 
     class Meta:
         model = Community
@@ -171,7 +170,6 @@ class GetCommunityCommunitySerializer(serializers.ModelSerializer):
             'avatar',
             'cover',
             'members_count',
-            'posts_count',
             'color',
             'description',
             'rules',

--- a/openbook_communities/views/community/views.py
+++ b/openbook_communities/views/community/views.py
@@ -10,8 +10,9 @@ from openbook_common.utils.helpers import normalise_request_data, normalize_list
 from openbook_communities.views.community.serializers import GetCommunityCommunitySerializer, DeleteCommunitySerializer, \
     UpdateCommunitySerializer, UpdateCommunityAvatarSerializer, UpdateCommunityCoverSerializer, GetCommunitySerializer, \
     FavoriteCommunitySerializer, CommunityAvatarCommunitySerializer, CommunityCoverCommunitySerializer, \
-    FavoriteCommunityCommunitySerializer, TopPostCommunityExclusionSerializer, SubscribeToCommunityNotificationsSerializer, \
-    SubscribeToCommunityNotificationsCommunitySerializer
+    FavoriteCommunityCommunitySerializer, TopPostCommunityExclusionSerializer, \
+    SubscribeToCommunityNotificationsSerializer, \
+    SubscribeToCommunityNotificationsCommunitySerializer, LegacyGetCommunityCommunitySerializer
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -25,7 +26,8 @@ class CommunityItem(APIView):
         user = request.user
         community = user.get_community_with_name(community_name)
 
-        response_serializer = GetCommunityCommunitySerializer(community, context={"request": request})
+        community_serializer = self._get_community_serializer()
+        response_serializer = community_serializer(community, context={"request": request})
 
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
@@ -69,10 +71,15 @@ class CommunityItem(APIView):
                                                         rules=rules, user_adjective=user_adjective,
                                                         users_adjective=users_adjective, categories_names=categories,
                                                         invites_enabled=invites_enabled)
-
-        response_serializer = GetCommunityCommunitySerializer(community, context={"request": request})
+        community_serializer = self._get_community_serializer()
+        response_serializer = community_serializer(community, context={"request": request})
 
         return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    def _get_community_serializer(self):
+        if self.request.version == '1.0':
+            return GetCommunityCommunitySerializer
+        return LegacyGetCommunityCommunitySerializer
 
 
 class CommunityAvatar(APIView):
@@ -226,7 +233,8 @@ class SubscribeToCommunityNewPostNotifications(APIView):
         with transaction.atomic():
             community = user.enable_new_post_notifications_for_community_with_name(community_name=community_name)
 
-        response_serializer = SubscribeToCommunityNotificationsCommunitySerializer(community, context={"request": request})
+        response_serializer = SubscribeToCommunityNotificationsCommunitySerializer(community,
+                                                                                   context={"request": request})
 
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
@@ -244,6 +252,7 @@ class SubscribeToCommunityNewPostNotifications(APIView):
         with transaction.atomic():
             community = user.disable_new_post_notifications_for_community_with_name(community_name=community_name)
 
-        response_serializer = SubscribeToCommunityNotificationsCommunitySerializer(community, context={"request": request})
+        response_serializer = SubscribeToCommunityNotificationsCommunitySerializer(community,
+                                                                                   context={"request": request})
 
         return Response(response_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
One issue though... it's not backwards compatible. People with older versions won't see posts counts in user profiles until the release is out.

It's ugly to add new routes, serializers and tests just because of this. Proper way is with API versioning. https://www.django-rest-framework.org/api-guide/versioning/

Will give it a go. If it's too much to kickstart, given it's not such a big thing we can deploy.