### PR TITLE
:bug: dont generate usernames anymore as we updated register flow

### DIFF
--- a/openbook_invitations/parsers.py
+++ b/openbook_invitations/parsers.py
@@ -50,8 +50,7 @@ def parse_indiegogo_csv(filepath):
 
                 if username is None or username == '0' or username is '':
                     print('Username was empty for:', name)
-                    username = get_temporary_username(email)
-                    print('Using generated random username @', username)
+                    username = None
                 invited_user = UserInvite.create_invite(name=name, email=email, username=username,
                                                         badge=badge)
                 invited_user.save()


### PR DESCRIPTION
We generate random usernames while importing invites, but now that we let users pick their usernames this can be removed from the parsing script. 

This is needed as un-used invites with random usernames assigned will block those random usernames from being taken by other users. 
