### PR TITLE
Hotfix private public error in communities

### DIFF
--- a/openbook_auth/checkers.py
+++ b/openbook_auth/checkers.py
@@ -123,7 +123,7 @@ def check_community_data(user, community, name=None, cover=None, avatar=None, ty
 
 def check_community_type_can_be_updated(type, community):
     Community = get_community_model()
-    if type == Community.COMMUNITY_TYPE_PUBLIC and community.is_private:
+    if type == Community.COMMUNITY_TYPE_PUBLIC and community.is_private():
         raise ValidationError(
             _('A community cannot be changed from private to public'),
         )

--- a/openbook_auth/checkers.py
+++ b/openbook_auth/checkers.py
@@ -113,9 +113,20 @@ def check_list_data(user, name):
         check_list_name_not_taken(user=user, list_name=name)
 
 
-def check_community_data(user, name=None, cover=None, avatar=None):
+def check_community_data(user, community, name=None, cover=None, avatar=None, type=None):
     if name:
         check_community_name_not_taken(user=user, community_name=name)
+
+    if type:
+        check_community_type_can_be_updated(type=type, community=community)
+
+
+def check_community_type_can_be_updated(type, community):
+    Community = get_community_model()
+    if type == Community.COMMUNITY_TYPE_PUBLIC and community.is_private:
+        raise ValidationError(
+            _('A community cannot be changed from private to public'),
+        )
 
 
 def check_circle_data(user, name, color):

--- a/openbook_auth/models.py
+++ b/openbook_auth/models.py
@@ -1465,10 +1465,11 @@ class User(AbstractUser):
                                    users_adjective=None, rules=None, categories_names=None,
                                    invites_enabled=None):
         check_can_update_community_with_name(user=self, community_name=community_name)
-        check_community_data(user=self, name=name)
 
         Community = get_community_model()
         community_to_update = Community.objects.get(name=community_name)
+
+        check_community_data(user=self, community=community_to_update, name=name, type=type)
 
         community_to_update.update(name=name, title=title, description=description,
                                    color=color, type=type, user_adjective=user_adjective,
@@ -1479,12 +1480,12 @@ class User(AbstractUser):
 
     def update_community_with_name_avatar(self, community_name, avatar):
         check_can_update_community_with_name(user=self, community_name=community_name)
-        check_community_data(user=self, avatar=avatar)
 
         Community = get_community_model()
         community_to_update_avatar_from = Community.objects.get(name=community_name)
-        community_to_update_avatar_from.avatar = avatar
+        check_community_data(user=self, community=community_to_update_avatar_from, avatar=avatar)
 
+        community_to_update_avatar_from.avatar = avatar
         community_to_update_avatar_from.save()
 
         return community_to_update_avatar_from
@@ -1500,10 +1501,10 @@ class User(AbstractUser):
 
     def update_community_with_name_cover(self, community_name, cover):
         check_can_update_community_with_name(user=self, community_name=community_name)
-        check_community_data(user=self, cover=cover)
 
         Community = get_community_model()
         community_to_update_cover_from = Community.objects.get(name=community_name)
+        check_community_data(user=self, community=community_to_update_cover_from, cover=cover)
 
         community_to_update_cover_from.cover = cover
 

--- a/openbook_communities/tests/views/community/test_views.py
+++ b/openbook_communities/tests/views/community/test_views.py
@@ -419,6 +419,31 @@ class CommunityAPITests(OpenbookAPITestCase):
 
         self.assertEqual(community.description, new_community_description)
 
+    def test_can_update_administrated_community_description_with_type_unchanged(self):
+        """
+        should be able to update an administrated community description with the same type
+        """
+        user = make_user()
+        headers = make_authentication_headers_for_user(user)
+
+        community = make_community(creator=user)
+        new_community_description = make_community_description()
+
+        data = {
+            'description': new_community_description,
+            'type': 'P'
+        }
+
+        url = self._get_url(community_name=community.name)
+
+        response = self.client.patch(url, data, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        community.refresh_from_db()
+
+        self.assertEqual(community.description, new_community_description)
+
     def test_can_update_administrated_community_rules(self):
         """
         should be able to update an administrated community rules

--- a/openbook_communities/tests/views/community/test_views.py
+++ b/openbook_communities/tests/views/community/test_views.py
@@ -249,6 +249,29 @@ class CommunityAPITests(OpenbookAPITestCase):
 
         self.assertEqual(community.type, new_community_type)
 
+    def test_cannot_update_private_community_type(self):
+        """
+        should NOT be able to update a private community type to public
+        """
+        user = make_user()
+        headers = make_authentication_headers_for_user(user)
+
+        community = make_community(creator=user, type='T')
+        new_community_type = 'P'
+
+        data = {
+            'type': new_community_type
+        }
+
+        url = self._get_url(community_name=community.name)
+
+        response = self.client.patch(url, data, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        community.refresh_from_db()
+
+        self.assertEqual(community.type, 'T')
+
     def test_can_update_administrated_community_title(self):
         """
         should be able to update an administrated community title


### PR DESCRIPTION
…ies-bug"

This reverts commit c01eae9f2904489623677c34d2edea8ca16e540e, reversing
changes made to 3bf79ccddbef7610dec249667fb5a011ff9f4ea7.

And fixes the public-private error message showing up when updating public communities.